### PR TITLE
Fix missing dash in programs.cfg

### DIFF
--- a/programs.cfg
+++ b/programs.cfg
@@ -19,7 +19,7 @@
       ["master/Stuff/Cowsay/apt"] = "/share/cowsay",
       ["master/Stuff/Cowsay/beavis.zen"] = "/share/cowsay",
       ["master/Stuff/Cowsay/bong"] = "/share/cowsay",
-      ["master/Stuff/Cowsay/budfrogs"] = "/share/cowsay",
+      ["master/Stuff/Cowsay/bud-frogs"] = "/share/cowsay",
       ["master/Stuff/Cowsay/bunny"] = "/share/cowsay",
       ["master/Stuff/Cowsay/calvin"] = "/share/cowsay",
       ["master/Stuff/Cowsay/cheese"] = "/share/cowsay",


### PR DESCRIPTION
Missing dash in `bud-frogs` caused oppm install to fail.